### PR TITLE
allow output type assertion

### DIFF
--- a/src/WrappedUnions.jl
+++ b/src/WrappedUnions.jl
@@ -57,20 +57,29 @@ end
 
 """
     @unionsplit f(args...; kwargs...)
+    # or
+    @unionsplit f(args...; kwargs...)::ReturnType
 
 Calls `unionsplit(f, args, kwargs)`. See its docstring for further information.
 """
 macro unionsplit(expr)
-    expr.head != :call && error("Expression is not a function call")
-    f = expr.args[1]
-    if expr.args[2] isa Expr && expr.args[2].head == :parameters
-        pos_args, kw_args = expr.args[3:end], expr.args[2].args
-    else
-        pos_args, kw_args = expr.args[2:end], []
+    ret_type = nothing
+    call_expr = expr
+
+    if call_expr isa Expr && call_expr.head == :(::)
+        call_expr, ret_type = call_expr.args
     end
-    return esc(quote
-        $WrappedUnions.unionsplit($f, ($(pos_args...),), (;$(kw_args...)))
-    end)
+
+    call_expr isa Expr && call_expr.head == :call || error("Expression is not a function call")
+    f = call_expr.args[1]
+    if call_expr.args[2] isa Expr && call_expr.args[2].head == :parameters
+        pos_args, kw_args = call_expr.args[3:end], call_expr.args[2].args
+    else
+        pos_args, kw_args = call_expr.args[2:end], []
+    end
+
+    call = :($WrappedUnions.unionsplit($f, ($(pos_args...),), (;$(kw_args...))))
+    return esc(isnothing(ret_type) ? call : :($call::$ret_type))
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,11 @@ splittedsum(x::Y{A,B}, y, z::X; q::X, t) where {A,B} = @unionsplit sumt(x, y, z;
     union::U
 end
 
-@testset "WrappedUnions.jl" begin
+@wrapped struct In
+    union::Union{Int64, Float64}
+end
+
+@testset "Basic Tests" begin
     
     if "CI" in keys(ENV)
         @testset "Code quality (Aqua.jl)" begin
@@ -94,15 +98,13 @@ end
     ou2 = OpenUnion{Union{Nothing, Char, Int, Float64}}(5)
     @test unwrap(ou2) == 5
     @test uniontype(ou2) == Union{Nothing, Char, Int, Float64}
+end
 
+if VERSION >= v"1.12"
     @testset "Type Widening" begin
         g(x::Int64) = x > 0 ? Union{Int64, Int32}[] : Int64[]
         g(x::Float64) = x > 0 ? Union{Float64, Float32}[] : Float64[]
-
-        @wrapped struct In
-            union::Union{Int64, Float64}
-        end
-
+    
         # type via module-level const alias
         g(x::In) = @unionsplit g(x)::TYPE_WIDEN_U
         out = Base.infer_return_type(g, (In,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,10 +107,12 @@ end
     # type via module-level const alias
     g(x::In) = @unionsplit g(x)::TYPE_WIDEN_U
     @inferred TYPE_WIDEN_U g(In(1))
+    @test g(In(1)) == Int64[]
 
     # define type directly inline
     h(x::In) = @unionsplit g(x)::Union{Vector{Int64}, Vector{Float64}, Vector{Union{Int64, Int32}}}
     @inferred TYPE_WIDEN_U h(In(1))
+    @test h(In(1)) == Int64[]
 end
 
 # benchmark

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using WrappedUnions
 
 using Aqua, Test
 
+const TYPE_WIDEN_U = Union{Vector{Int64}, Vector{Float64}, Vector{Union{Int64, Int32}}}
+
 "docstring"
 @wrapped struct K 
     union::Union{Int}
@@ -92,6 +94,24 @@ end
     ou2 = OpenUnion{Union{Nothing, Char, Int, Float64}}(5)
     @test unwrap(ou2) == 5
     @test uniontype(ou2) == Union{Nothing, Char, Int, Float64}
+
+    @testset "Type Widening" begin
+        g(x::Int64) = x > 0 ? Union{Int64, Int32}[] : Int64[]
+        g(x::Float64) = x > 0 ? Union{Float64, Float32}[] : Float64[]
+
+        @wrapped struct In
+            union::Union{Int64, Float64}
+        end
+
+        # type via module-level const alias
+        g(x::In) = @unionsplit g(x)::TYPE_WIDEN_U
+        out = Base.infer_return_type(g, (In,))
+        @test out == TYPE_WIDEN_U
+        # define type directly inline
+        h(x::In) = @unionsplit g(x)::Union{Vector{Int64}, Vector{Float64}, Vector{Union{Int64, Int32}}}
+        out2 = Base.infer_return_type(h, (In,))
+        @test out2 == TYPE_WIDEN_U
+    end
 end
 
 # benchmark

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,20 +100,17 @@ end
     @test uniontype(ou2) == Union{Nothing, Char, Int, Float64}
 end
 
-if VERSION >= v"1.12"
-    @testset "Type Widening" begin
-        g(x::Int64) = x > 0 ? Union{Int64, Int32}[] : Int64[]
-        g(x::Float64) = x > 0 ? Union{Float64, Float32}[] : Float64[]
+@testset "Type Widening" begin
+    g(x::Int64) = x > 0 ? Union{Int64, Int32}[] : Int64[]
+    g(x::Float64) = x > 0 ? Union{Float64, Float32}[] : Float64[]
     
-        # type via module-level const alias
-        g(x::In) = @unionsplit g(x)::TYPE_WIDEN_U
-        out = Base.infer_return_type(g, (In,))
-        @test out == TYPE_WIDEN_U
-        # define type directly inline
-        h(x::In) = @unionsplit g(x)::Union{Vector{Int64}, Vector{Float64}, Vector{Union{Int64, Int32}}}
-        out2 = Base.infer_return_type(h, (In,))
-        @test out2 == TYPE_WIDEN_U
-    end
+    # type via module-level const alias
+    g(x::In) = @unionsplit g(x)::TYPE_WIDEN_U
+    @inferred TYPE_WIDEN_U g(In(1))
+
+    # define type directly inline
+    h(x::In) = @unionsplit g(x)::Union{Vector{Int64}, Vector{Float64}, Vector{Union{Int64, Int32}}}
+    @inferred TYPE_WIDEN_U h(In(1))
 end
 
 # benchmark


### PR DESCRIPTION
This solves my issue: https://github.com/ameligrana/WrappedUnions.jl/issues/30

The macro now takes the output type assertion into consideration, which is basically all I needed:

```julia
julia> @macroexpand f(x::X) = @unionsplit f(x)
:(f(x::X) = begin
          (WrappedUnions).unionsplit(f, (x,), (;))
      end)

julia> @macroexpand f(x::X) = @unionsplit f(x)::Real
:(f(x::X) = begin
          (WrappedUnions).unionsplit(f, (x,), (;))::Real
      end)
```